### PR TITLE
adding lab start files to make cloud foundry config easier

### DIFF
--- a/catalog/src/main/resources/application.yml.cloudfoundry
+++ b/catalog/src/main/resources/application.yml.cloudfoundry
@@ -1,0 +1,29 @@
+# Server configuration
+server:
+  context-path: /micro
+  port: 8080
+vcap:
+  uri: ${vcap.services.mysqldb.credentials.uri}
+# Spring properties
+spring:
+  application:
+     name: catalog-microservice
+
+  # MySQL Data source configuration
+  datasource:
+    driverClassName: com.mysql.jdbc.Driver
+    url: ""
+    username: admin
+    password: ""
+    port: 3306
+    max-active: 4
+    testOnBorrow: true
+    validationQuery: SELECT 1
+
+  jpa:
+    database: MYSQL
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+      naming-strategy: org.hibernate.cfg.ImprovedNamingStrategy
+

--- a/customer/src/main/resources/application.yml.cloudfoundry
+++ b/customer/src/main/resources/application.yml.cloudfoundry
@@ -1,0 +1,16 @@
+# Server configuration
+server:
+  context-path: /micro
+  port: 8080
+
+# Spring properties
+spring:
+  application:
+     name: customer-microservice
+
+     cloudant:
+        username: ${vcap.services.cloudantdb.credentials.username}
+        password: ${vcap.services.cloudantdb.credentials.password}
+        host: ${vcap.services.cloudantdb.credentials.host}
+        port: ${vcap.services.cloudantdb.credentials.port}
+        database: customers


### PR DESCRIPTION
I've added cloud foundry application.yml template files for customer and catalog apps. I have written my labs to expect them and they will help to reduce student error. I also changed the starting content of default.json and manifest.yml to values matching the cloud foundry configuration as is the starting state of configuration files for customer and catalog. Somehow the starting state of these web app files in the repo was having them already configured for cloud foundry.